### PR TITLE
Update download links for OpenTTD

### DIFF
--- a/automatic/openttd/tools/chocolateyInstall.ps1
+++ b/automatic/openttd/tools/chocolateyInstall.ps1
@@ -2,8 +2,8 @@
 
 $packageName = "openttd"
 $fileType    = "exe"
-$url32       = "https://proxy.binaries.openttd.org/openttd-releases/13.3/openttd-13.3-windows-win32.exe"
-$url64       = "https://proxy.binaries.openttd.org/openttd-releases/13.3/openttd-13.3-windows-win64.exe"
+$url32       = "https://cdn.openttd.org/openttd-releases/13.3/openttd-13.3-windows-win32.exe"
+$url64       = "https://cdn.openttd.org/openttd-releases/13.3/openttd-13.3-windows-win64.exe"
 $checksum32  = "6c0722a23d0ee320b0bafff351f5b2132df38fc386fc9bb900507007fa2965bb"
 $checksum64  = "4ef745f5cb34b86a7e5d525c60b22c544c9f9da11e86698c0d12e252468084a0"
 

--- a/automatic/openttd/update.ps1
+++ b/automatic/openttd/update.ps1
@@ -17,9 +17,9 @@ function global:au_GetLatest {
     $Release = Invoke-WebRequest -Uri $Uri -UseBasicParsing | ConvertFrom-Json
 
     $Version = $Release.tag_name
-    $Url32 = "https://proxy.binaries.openttd.org/openttd-releases/" + $Version + "/openttd-" + $Version + "-windows-win32.exe"
-    $Url64 = "https://proxy.binaries.openttd.org/openttd-releases/" + $Version + "/openttd-" + $Version + "-windows-win64.exe"
-
+    $Url32 = "https://cdn.openttd.org/openttd-releases/" + $Version + "/openttd-" + $Version + "-windows-win32.exe"
+    $Url64 = "https://cdn.openttd.org/openttd-releases/" + $Version + "/openttd-" + $Version + "-windows-win64.exe"
+    
     $Latest = @{
         URL32 = $Url32
         URL64 = $Url64


### PR DESCRIPTION
**Describe the change**
Download links changed to cdn.openttd.org
**Current behavior**
404 error
**New behavior**
Downloading without problems.
